### PR TITLE
Draft: Add tests for node native `fetch` interceptor (WIP)

### DIFF
--- a/package.json
+++ b/package.json
@@ -64,6 +64,7 @@
     "supertest": "^6.1.6",
     "ts-jest": "^28.0.8",
     "typescript": "4.3.5",
+    "undici": "^5.10.0",
     "wait-for-expect": "^3.0.2"
   },
   "dependencies": {

--- a/src/interceptors/fetch/index.ts
+++ b/src/interceptors/fetch/index.ts
@@ -53,7 +53,10 @@ export class FetchInterceptor extends Interceptor<HttpRequestEventMap> {
 
       const body = await request.clone().arrayBuffer()
       const isomorphicRequest = new IsomorphicRequest(
-        new URL(url, location.origin),
+        new URL(
+          url,
+          typeof location !== 'undefined' ? location.origin : undefined
+        ),
         {
           body,
           method,

--- a/src/interceptors/fetch/index.ts
+++ b/src/interceptors/fetch/index.ts
@@ -121,7 +121,16 @@ export class FetchInterceptor extends Interceptor<HttpRequestEventMap> {
 
       this.log('no mocked response received!')
 
-      return pureFetch(request).then(async (response) => {
+      // NOTE: Make sure to properly pass through undici requests with dispatcher
+      // undici accepts an additional `dispatcher` property on `RequestInit`,
+      // which may have been defined in the object passed as `init`, but we
+      // lose it when we instantiate `new Request(input, init)`. So, check if
+      // it was initially provided, and include it in second arg to fetch if so.
+      const maybeUndiciOpts = init?.dispatcher
+        ? ({ dispatcher: init.dispatcher } as RequestInit)
+        : undefined
+
+      return pureFetch(request, maybeUndiciOpts).then(async (response) => {
         const cloneResponse = response.clone()
         this.log('original fetch performed', cloneResponse)
 
@@ -160,5 +169,15 @@ async function normalizeFetchResponse(
     statusText: response.statusText,
     headers: objectToHeaders(headersToObject(response.headers)),
     body: await response.text(),
+  }
+}
+
+declare global {
+  interface RequestInit {
+    /**
+     * Optional property which is valid only in Node v18+ when using undici
+     * see: https://undici.nodejs.org/#/?id=undicifetchinput-init-promise
+     */
+    dispatcher?: import('undici').Agent
   }
 }

--- a/test/jest.expect.ts
+++ b/test/jest.expect.ts
@@ -5,8 +5,15 @@ import { HeadersObject } from 'headers-polyfill'
  * A custom asymetric matcher that asserts the `Headers` object.
  */
 class HeadersContaining extends AsymmetricMatcher<Record<string, unknown>> {
-  constructor(sample: Record<string, unknown>, inverse = false) {
-    super(sample, inverse)
+  constructor(
+    sample: Record<string, unknown> | { raw(): Record<string, unknown> },
+    inverse = false
+  ) {
+    if (sample.hasOwnProperty('raw') && typeof sample.raw === 'function') {
+      super(sample.raw(), inverse)
+    } else {
+      super(sample, inverse)
+    }
   }
 
   asymmetricMatch(other: Headers) {

--- a/test/jest.node.config.js
+++ b/test/jest.node.config.js
@@ -1,5 +1,13 @@
+const [majorNodeVersion, _minorNodeVersion, _patchNodeVersion] = process.version
+  .split('.')
+  .map((x) => parseInt(x[0] === 'v' ? x.slice(1) : x))
+
+// Only include test files containing `node-native` when running on v18 or later
+const hasNativeFetch = majorNodeVersion >= 18
+const excludePattern = hasNativeFetch ? 'browser' : 'browser|node-native'
+
 module.exports = {
-  testRegex: '(?<!browser.*)(\\.test)\\.ts$',
+  testRegex: '(?<!(' + excludePattern + ').*)(\\.test)\\.ts$',
   transform: {
     '^.+\\.ts$': 'ts-jest',
   },

--- a/test/modules/fetch/intercept/fetch.node-native.test.ts
+++ b/test/modules/fetch/intercept/fetch.node-native.test.ts
@@ -1,6 +1,7 @@
 /**
  * @jest-environment node
  */
+import { Agent } from 'undici'
 import { RequestHandler } from 'express'
 import { HttpServer } from '@open-draft/test-server/http'
 import { HttpRequestEventMap } from '../../../../src'
@@ -24,12 +25,13 @@ const httpServer = new HttpServer((app) => {
 const resolver = jest.fn<never, Parameters<HttpRequestEventMap['request']>>()
 
 const interceptor = new FetchInterceptor()
+
+const httpsDispatcher = new Agent({
+  connect: { rejectUnauthorized: false, requestCert: false },
+})
+
 interceptor.on('request', resolver)
 // interceptor.on('request', (...args) => {
-//   console.log('INTERCEPTED REQUEST....')
-
-//   debugger
-
 //   return resolver(...args)
 // })
 
@@ -216,159 +218,172 @@ test('can get the https url', async () => {
   expect(httpsUrl).toBeDefined()
 })
 
-// test('intercepts an HTTPS HEAD request', async () => {
-//   await fetch(httpServer.https.url('/user?id=123'), {
-//     method: 'HEAD',
-//     headers: {
-//       'x-custom-header': 'yes',
-//     },
-//   })
+test('intercepts an HTTPS HEAD request', async () => {
+  await fetch(httpServer.https.url('/user?id=123'), {
+    dispatcher: httpsDispatcher,
+    method: 'HEAD',
+    headers: {
+      'x-custom-header': 'yes',
+    },
+  })
 
-//   expect(resolver).toHaveBeenCalledTimes(1)
-//   expect(resolver).toHaveBeenCalledWith<
-//     Parameters<HttpRequestEventMap['request']>
-//   >(
-//     expect.objectContaining({
-//       id: anyUuid(),
-//       method: 'HEAD',
-//       url: new URL(httpServer.https.url('/user?id=123')),
-//       headers: headersContaining({
-//         'x-custom-header': 'yes',
-//       }),
-//       credentials: 'same-origin',
-//       _body: encodeBuffer(''),
-//       respondWith: expect.any(Function),
-//     })
-//   )
-// })
+  expect(resolver).toHaveBeenCalledTimes(1)
+  expect(resolver).toHaveBeenCalledWith<
+    Parameters<HttpRequestEventMap['request']>
+  >(
+    expect.objectContaining({
+      id: anyUuid(),
+      method: 'HEAD',
+      url: new URL(httpServer.https.url('/user?id=123')),
+      headers: headersContaining({
+        'x-custom-header': 'yes',
+      }),
+      credentials: 'same-origin',
+      _body: encodeBuffer(''),
+      respondWith: expect.any(Function),
+    })
+  )
+})
 
-// test('intercepts an HTTPS GET request', async () => {
-//   await fetch(httpServer.https.url('/user?id=123'), {
-//     headers: {
-//       'x-custom-header': 'yes',
-//     },
-//   })
+test('intercepts an HTTPS GET request', async () => {
+  await fetch(httpServer.https.url('/user?id=123'), {
+    dispatcher: httpsDispatcher,
+    headers: {
+      'x-custom-header': 'yes',
+    },
+  })
 
-//   expect(resolver).toHaveBeenCalledTimes(1)
-//   expect(resolver).toHaveBeenCalledWith<
-//     Parameters<HttpRequestEventMap['request']>
-//   >(
-//     expect.objectContaining({
-//       id: anyUuid(),
-//       method: 'GET',
-//       url: new URL(httpServer.https.url('/user?id=123')),
-//       headers: headersContaining({
-//         'x-custom-header': 'yes',
-//       }),
-//       credentials: 'same-origin',
-//       _body: encodeBuffer(''),
-//       respondWith: expect.any(Function),
-//     })
-//   )
-// })
+  expect(resolver).toHaveBeenCalledTimes(1)
+  expect(resolver).toHaveBeenCalledWith<
+    Parameters<HttpRequestEventMap['request']>
+  >(
+    expect.objectContaining({
+      id: anyUuid(),
+      method: 'GET',
+      url: new URL(httpServer.https.url('/user?id=123')),
+      headers: headersContaining({
+        'x-custom-header': 'yes',
+      }),
+      credentials: 'same-origin',
+      _body: encodeBuffer(''),
+      respondWith: expect.any(Function),
+    })
+  )
+})
 
-// test('intercepts an HTTPS POST request', async () => {
-//   await fetch(httpServer.https.url('/user?id=123'), {
-//     method: 'POST',
-//     headers: {
-//       'x-custom-header': 'yes',
-//     },
-//     body: JSON.stringify({ body: true }),
-//   })
+test('intercepts an HTTPS POST request', async () => {
+  await fetch(httpServer.https.url('/user?id=123'), {
+    dispatcher: httpsDispatcher,
+    method: 'POST',
+    headers: {
+      'x-custom-header': 'yes',
+    },
+    body: JSON.stringify({ body: true }),
+  })
 
-//   expect(resolver).toHaveBeenCalledTimes(1)
-//   expect(resolver).toHaveBeenCalledWith<
-//     Parameters<HttpRequestEventMap['request']>
-//   >(
-//     expect.objectContaining({
-//       id: anyUuid(),
-//       method: 'POST',
-//       url: new URL(httpServer.https.url('/user?id=123')),
-//       headers: headersContaining({
-//         'x-custom-header': 'yes',
-//       }),
-//       credentials: 'same-origin',
-//       _body: encodeBuffer(JSON.stringify({ body: true })),
-//       respondWith: expect.any(Function),
-//     })
-//   )
-// })
+  expect(resolver).toHaveBeenCalledTimes(1)
+  expect(resolver).toHaveBeenCalledWith<
+    Parameters<HttpRequestEventMap['request']>
+  >(
+    expect.objectContaining({
+      id: anyUuid(),
+      method: 'POST',
+      url: new URL(httpServer.https.url('/user?id=123')),
+      headers: headersContaining({
+        'x-custom-header': 'yes',
+      }),
+      credentials: 'same-origin',
+      _body: encodeBuffer(JSON.stringify({ body: true })),
+      respondWith: expect.any(Function),
+    })
+  )
+})
 
-// test('intercepts an HTTPS PUT request', async () => {
-//   await fetch(httpServer.https.url('/user?id=123'), {
-//     method: 'PUT',
-//     headers: {
-//       'x-custom-header': 'yes',
-//     },
-//     body: encodeBuffer('request-payload'),
-//   })
+test('intercepts an HTTPS PUT request', async () => {
+  await fetch(httpServer.https.url('/user?id=123'), {
+    dispatcher: httpsDispatcher,
+    method: 'PUT',
+    headers: {
+      'x-custom-header': 'yes',
+    },
+    body: encodeBuffer('request-payload'),
+  })
 
-//   expect(resolver).toHaveBeenCalledTimes(1)
-//   expect(resolver).toHaveBeenCalledWith<
-//     Parameters<HttpRequestEventMap['request']>
-//   >(
-//     expect.objectContaining({
-//       id: anyUuid(),
-//       method: 'PUT',
-//       url: new URL(httpServer.https.url('/user?id=123')),
-//       headers: headersContaining({
-//         'x-custom-header': 'yes',
-//       }),
-//       credentials: 'same-origin',
-//       _body: encodeBuffer('request-payload'),
-//       respondWith: expect.any(Function),
-//     })
-//   )
-// })
+  expect(resolver).toHaveBeenCalledTimes(1)
+  expect(resolver).toHaveBeenCalledWith<
+    Parameters<HttpRequestEventMap['request']>
+  >(
+    expect.objectContaining({
+      id: anyUuid(),
+      method: 'PUT',
+      url: new URL(httpServer.https.url('/user?id=123')),
+      headers: headersContaining({
+        'x-custom-header': 'yes',
+      }),
+      credentials: 'same-origin',
+      _body: encodeBuffer('request-payload'),
+      respondWith: expect.any(Function),
+    })
+  )
+})
 
-// test('intercepts an HTTPS DELETE request', async () => {
-//   await fetch(httpServer.https.url('/user?id=123'), {
-//     method: 'DELETE',
-//     headers: {
-//       'x-custom-header': 'yes',
-//     },
-//   })
+test('intercepts an HTTPS DELETE request', async () => {
+  await fetch(httpServer.https.url('/user?id=123'), {
+    dispatcher: httpsDispatcher,
+    method: 'DELETE',
+    headers: {
+      'x-custom-header': 'yes',
+    },
+  })
 
-//   expect(resolver).toHaveBeenCalledTimes(1)
-//   expect(resolver).toHaveBeenCalledWith<
-//     Parameters<HttpRequestEventMap['request']>
-//   >(
-//     expect.objectContaining({
-//       id: anyUuid(),
-//       method: 'DELETE',
-//       url: new URL(httpServer.https.url('/user?id=123')),
-//       headers: headersContaining({
-//         'x-custom-header': 'yes',
-//       }),
-//       credentials: 'same-origin',
-//       _body: encodeBuffer(''),
-//       respondWith: expect.any(Function),
-//     })
-//   )
-// })
+  expect(resolver).toHaveBeenCalledTimes(1)
+  expect(resolver).toHaveBeenCalledWith<
+    Parameters<HttpRequestEventMap['request']>
+  >(
+    expect.objectContaining({
+      id: anyUuid(),
+      method: 'DELETE',
+      url: new URL(httpServer.https.url('/user?id=123')),
+      headers: headersContaining({
+        'x-custom-header': 'yes',
+      }),
+      credentials: 'same-origin',
+      _body: encodeBuffer(''),
+      respondWith: expect.any(Function),
+    })
+  )
+})
 
-// test('intercepts an HTTPS PATCH request', async () => {
-//   await fetch(httpServer.https.url('/user?id=123'), {
-//     method: 'PATCH',
-//     headers: {
-//       'x-custom-header': 'yes',
-//     },
-//   })
+test('intercepts an HTTPS PATCH request', async () => {
+  await fetch(httpServer.https.url('/user?id=123'), {
+    dispatcher: httpsDispatcher,
+    method: 'PATCH',
+    headers: {
+      'x-custom-header': 'yes',
+    },
+  })
 
-//   expect(resolver).toHaveBeenCalledTimes(1)
-//   expect(resolver).toHaveBeenCalledWith<
-//     Parameters<HttpRequestEventMap['request']>
-//   >(
-//     expect.objectContaining({
-//       id: anyUuid(),
-//       method: 'PATCH',
-//       url: new URL(httpServer.https.url('/user?id=123')),
-//       headers: headersContaining({
-//         'x-custom-header': 'yes',
-//       }),
-//       credentials: 'same-origin',
-//       _body: encodeBuffer(''),
-//       respondWith: expect.any(Function),
-//     })
-//   )
-// })
+  expect(resolver).toHaveBeenCalledTimes(1)
+  expect(resolver).toHaveBeenCalledWith<
+    Parameters<HttpRequestEventMap['request']>
+  >(
+    expect.objectContaining({
+      id: anyUuid(),
+      method: 'PATCH',
+      url: new URL(httpServer.https.url('/user?id=123')),
+      headers: headersContaining({
+        'x-custom-header': 'yes',
+      }),
+      credentials: 'same-origin',
+      _body: encodeBuffer(''),
+      respondWith: expect.any(Function),
+    })
+  )
+})
+
+declare global {
+  interface RequestInit {
+    // see: https://undici.nodejs.org/#/?id=undicifetchinput-init-promise
+    dispatcher?: import('undici').Agent
+  }
+}

--- a/test/modules/fetch/intercept/fetch.node-native.test.ts
+++ b/test/modules/fetch/intercept/fetch.node-native.test.ts
@@ -50,8 +50,6 @@ afterAll(async () => {
 })
 
 test('intercepts an HTTP HEAD request', async () => {
-  console.log('httpServer.http.url(/user) = ', httpServer.http.url('/user'))
-
   await fetch(httpServer.http.url('/user?id=123'), {
     method: 'HEAD',
     headers: {
@@ -212,9 +210,6 @@ test('intercepts an HTTP PATCH request', async () => {
 
 test('can get the https url', async () => {
   const httpsUrl = httpServer.https.url('/user?id=123')
-
-  console.log('httpsUrl ----->', httpsUrl)
-
   expect(httpsUrl).toBeDefined()
 })
 

--- a/test/modules/fetch/intercept/fetch.node-native.test.ts
+++ b/test/modules/fetch/intercept/fetch.node-native.test.ts
@@ -1,0 +1,374 @@
+/**
+ * @jest-environment node
+ */
+import { RequestHandler } from 'express'
+import { HttpServer } from '@open-draft/test-server/http'
+import { HttpRequestEventMap } from '../../../../src'
+import { anyUuid, headersContaining } from '../../../jest.expect'
+import { FetchInterceptor } from '../../../../src/interceptors/fetch'
+import { encodeBuffer } from '../../../../src/utils/bufferUtils'
+
+const httpServer = new HttpServer((app) => {
+  const handleUserRequest: RequestHandler = (_req, res) => {
+    res.status(200).send('user-body').end()
+  }
+
+  app.get('/user', handleUserRequest)
+  app.post('/user', handleUserRequest)
+  app.put('/user', handleUserRequest)
+  app.delete('/user', handleUserRequest)
+  app.patch('/user', handleUserRequest)
+  app.head('/user', handleUserRequest)
+})
+
+const resolver = jest.fn<never, Parameters<HttpRequestEventMap['request']>>()
+
+const interceptor = new FetchInterceptor()
+interceptor.on('request', resolver)
+// interceptor.on('request', (...args) => {
+//   console.log('INTERCEPTED REQUEST....')
+
+//   debugger
+
+//   return resolver(...args)
+// })
+
+beforeAll(async () => {
+  await httpServer.listen()
+  interceptor.apply()
+})
+
+afterEach(() => {
+  jest.resetAllMocks()
+})
+
+afterAll(async () => {
+  interceptor.dispose()
+  await httpServer.close()
+})
+
+test('intercepts an HTTP HEAD request', async () => {
+  console.log('httpServer.http.url(/user) = ', httpServer.http.url('/user'))
+
+  await fetch(httpServer.http.url('/user?id=123'), {
+    method: 'HEAD',
+    headers: {
+      'x-custom-header': 'yes',
+    },
+  })
+
+  expect(resolver).toHaveBeenCalledTimes(1)
+  expect(resolver).toHaveBeenCalledWith<
+    Parameters<HttpRequestEventMap['request']>
+  >(
+    expect.objectContaining({
+      id: anyUuid(),
+      method: 'HEAD',
+      url: new URL(httpServer.http.url('/user?id=123')),
+      headers: headersContaining({
+        'x-custom-header': 'yes',
+      }),
+      credentials: 'same-origin',
+      _body: encodeBuffer(''),
+      respondWith: expect.any(Function),
+    })
+  )
+})
+
+test('intercepts an HTTP GET request', async () => {
+  await fetch(httpServer.http.url('/user?id=123'), {
+    headers: {
+      'x-custom-header': 'yes',
+    },
+  })
+
+  expect(resolver).toHaveBeenCalledTimes(1)
+  expect(resolver).toHaveBeenCalledWith<
+    Parameters<HttpRequestEventMap['request']>
+  >(
+    expect.objectContaining({
+      id: anyUuid(),
+      method: 'GET',
+      url: new URL(httpServer.http.url('/user?id=123')),
+      headers: headersContaining({
+        'x-custom-header': 'yes',
+      }),
+      credentials: 'same-origin',
+      _body: encodeBuffer(''),
+      respondWith: expect.any(Function),
+    })
+  )
+})
+
+test('intercepts an HTTP POST request', async () => {
+  await fetch(httpServer.http.url('/user?id=123'), {
+    method: 'POST',
+    headers: {
+      'x-custom-header': 'yes',
+    },
+    body: JSON.stringify({ body: true }),
+  })
+
+  expect(resolver).toHaveBeenCalledTimes(1)
+  expect(resolver).toHaveBeenCalledWith<
+    Parameters<HttpRequestEventMap['request']>
+  >(
+    expect.objectContaining({
+      id: anyUuid(),
+      method: 'POST',
+      url: new URL(httpServer.http.url('/user?id=123')),
+      headers: headersContaining({
+        // accept: '*/*', /* NOTE: node-native differs from browser, which does add this accept header */
+        'x-custom-header': 'yes',
+      }),
+      credentials: 'same-origin',
+      _body: encodeBuffer(JSON.stringify({ body: true })),
+      respondWith: expect.any(Function),
+    })
+  )
+})
+
+test('intercepts an HTTP PUT request', async () => {
+  await fetch(httpServer.http.url('/user?id=123'), {
+    method: 'PUT',
+    headers: {
+      'x-custom-header': 'yes',
+    },
+    body: encodeBuffer('request-payload'),
+  })
+
+  expect(resolver).toHaveBeenCalledTimes(1)
+  expect(resolver).toHaveBeenCalledWith<
+    Parameters<HttpRequestEventMap['request']>
+  >(
+    expect.objectContaining({
+      id: anyUuid(),
+      method: 'PUT',
+      url: new URL(httpServer.http.url('/user?id=123')),
+      headers: headersContaining({
+        'x-custom-header': 'yes',
+      }),
+      credentials: 'same-origin',
+      _body: encodeBuffer('request-payload'),
+      respondWith: expect.any(Function),
+    })
+  )
+})
+
+test('intercepts an HTTP DELETE request', async () => {
+  await fetch(httpServer.http.url('/user?id=123'), {
+    method: 'DELETE',
+    headers: {
+      'x-custom-header': 'yes',
+    },
+  })
+
+  expect(resolver).toHaveBeenCalledTimes(1)
+  expect(resolver).toHaveBeenCalledWith<
+    Parameters<HttpRequestEventMap['request']>
+  >(
+    expect.objectContaining({
+      id: anyUuid(),
+      method: 'DELETE',
+      url: new URL(httpServer.http.url('/user?id=123')),
+      headers: headersContaining({
+        'x-custom-header': 'yes',
+      }),
+      credentials: 'same-origin',
+      _body: encodeBuffer(''),
+      respondWith: expect.any(Function),
+    })
+  )
+})
+
+test('intercepts an HTTP PATCH request', async () => {
+  await fetch(httpServer.http.url('/user?id=123'), {
+    method: 'PATCH',
+    headers: {
+      'x-custom-header': 'yes',
+    },
+    body: encodeBuffer('request-payload'),
+  })
+
+  expect(resolver).toHaveBeenCalledTimes(1)
+  expect(resolver).toHaveBeenCalledWith<
+    Parameters<HttpRequestEventMap['request']>
+  >(
+    expect.objectContaining({
+      id: anyUuid(),
+      method: 'PATCH',
+      url: new URL(httpServer.http.url('/user?id=123')),
+      headers: headersContaining({
+        'x-custom-header': 'yes',
+      }),
+      credentials: 'same-origin',
+      _body: encodeBuffer('request-payload'),
+      respondWith: expect.any(Function),
+    })
+  )
+})
+
+test('can get the https url', async () => {
+  const httpsUrl = httpServer.https.url('/user?id=123')
+
+  console.log('httpsUrl ----->', httpsUrl)
+
+  expect(httpsUrl).toBeDefined()
+})
+
+// test('intercepts an HTTPS HEAD request', async () => {
+//   await fetch(httpServer.https.url('/user?id=123'), {
+//     method: 'HEAD',
+//     headers: {
+//       'x-custom-header': 'yes',
+//     },
+//   })
+
+//   expect(resolver).toHaveBeenCalledTimes(1)
+//   expect(resolver).toHaveBeenCalledWith<
+//     Parameters<HttpRequestEventMap['request']>
+//   >(
+//     expect.objectContaining({
+//       id: anyUuid(),
+//       method: 'HEAD',
+//       url: new URL(httpServer.https.url('/user?id=123')),
+//       headers: headersContaining({
+//         'x-custom-header': 'yes',
+//       }),
+//       credentials: 'same-origin',
+//       _body: encodeBuffer(''),
+//       respondWith: expect.any(Function),
+//     })
+//   )
+// })
+
+// test('intercepts an HTTPS GET request', async () => {
+//   await fetch(httpServer.https.url('/user?id=123'), {
+//     headers: {
+//       'x-custom-header': 'yes',
+//     },
+//   })
+
+//   expect(resolver).toHaveBeenCalledTimes(1)
+//   expect(resolver).toHaveBeenCalledWith<
+//     Parameters<HttpRequestEventMap['request']>
+//   >(
+//     expect.objectContaining({
+//       id: anyUuid(),
+//       method: 'GET',
+//       url: new URL(httpServer.https.url('/user?id=123')),
+//       headers: headersContaining({
+//         'x-custom-header': 'yes',
+//       }),
+//       credentials: 'same-origin',
+//       _body: encodeBuffer(''),
+//       respondWith: expect.any(Function),
+//     })
+//   )
+// })
+
+// test('intercepts an HTTPS POST request', async () => {
+//   await fetch(httpServer.https.url('/user?id=123'), {
+//     method: 'POST',
+//     headers: {
+//       'x-custom-header': 'yes',
+//     },
+//     body: JSON.stringify({ body: true }),
+//   })
+
+//   expect(resolver).toHaveBeenCalledTimes(1)
+//   expect(resolver).toHaveBeenCalledWith<
+//     Parameters<HttpRequestEventMap['request']>
+//   >(
+//     expect.objectContaining({
+//       id: anyUuid(),
+//       method: 'POST',
+//       url: new URL(httpServer.https.url('/user?id=123')),
+//       headers: headersContaining({
+//         'x-custom-header': 'yes',
+//       }),
+//       credentials: 'same-origin',
+//       _body: encodeBuffer(JSON.stringify({ body: true })),
+//       respondWith: expect.any(Function),
+//     })
+//   )
+// })
+
+// test('intercepts an HTTPS PUT request', async () => {
+//   await fetch(httpServer.https.url('/user?id=123'), {
+//     method: 'PUT',
+//     headers: {
+//       'x-custom-header': 'yes',
+//     },
+//     body: encodeBuffer('request-payload'),
+//   })
+
+//   expect(resolver).toHaveBeenCalledTimes(1)
+//   expect(resolver).toHaveBeenCalledWith<
+//     Parameters<HttpRequestEventMap['request']>
+//   >(
+//     expect.objectContaining({
+//       id: anyUuid(),
+//       method: 'PUT',
+//       url: new URL(httpServer.https.url('/user?id=123')),
+//       headers: headersContaining({
+//         'x-custom-header': 'yes',
+//       }),
+//       credentials: 'same-origin',
+//       _body: encodeBuffer('request-payload'),
+//       respondWith: expect.any(Function),
+//     })
+//   )
+// })
+
+// test('intercepts an HTTPS DELETE request', async () => {
+//   await fetch(httpServer.https.url('/user?id=123'), {
+//     method: 'DELETE',
+//     headers: {
+//       'x-custom-header': 'yes',
+//     },
+//   })
+
+//   expect(resolver).toHaveBeenCalledTimes(1)
+//   expect(resolver).toHaveBeenCalledWith<
+//     Parameters<HttpRequestEventMap['request']>
+//   >(
+//     expect.objectContaining({
+//       id: anyUuid(),
+//       method: 'DELETE',
+//       url: new URL(httpServer.https.url('/user?id=123')),
+//       headers: headersContaining({
+//         'x-custom-header': 'yes',
+//       }),
+//       credentials: 'same-origin',
+//       _body: encodeBuffer(''),
+//       respondWith: expect.any(Function),
+//     })
+//   )
+// })
+
+// test('intercepts an HTTPS PATCH request', async () => {
+//   await fetch(httpServer.https.url('/user?id=123'), {
+//     method: 'PATCH',
+//     headers: {
+//       'x-custom-header': 'yes',
+//     },
+//   })
+
+//   expect(resolver).toHaveBeenCalledTimes(1)
+//   expect(resolver).toHaveBeenCalledWith<
+//     Parameters<HttpRequestEventMap['request']>
+//   >(
+//     expect.objectContaining({
+//       id: anyUuid(),
+//       method: 'PATCH',
+//       url: new URL(httpServer.https.url('/user?id=123')),
+//       headers: headersContaining({
+//         'x-custom-header': 'yes',
+//       }),
+//       credentials: 'same-origin',
+//       _body: encodeBuffer(''),
+//       respondWith: expect.any(Function),
+//     })
+//   )
+// })

--- a/yarn.lock
+++ b/yarn.lock
@@ -6101,6 +6101,11 @@ unbox-primitive@^1.0.2:
     has-symbols "^1.0.3"
     which-boxed-primitive "^1.0.2"
 
+undici@^5.10.0:
+  version "5.10.0"
+  resolved "https://registry.yarnpkg.com/undici/-/undici-5.10.0.tgz#dd9391087a90ccfbd007568db458674232ebf014"
+  integrity sha512-c8HsD3IbwmjjbLvoZuRI26TZic+TSEe8FPMLLOkN1AfYRhdjnKBU6yL+IwcSCbdZiX4e5t0lfMDLDCqj4Sq70g==
+
 universalify@^0.1.0:
   version "0.1.2"
   resolved "https://registry.yarnpkg.com/universalify/-/universalify-0.1.2.tgz#b646f69be3942dabcecc9d6639c80dc105efaa66"


### PR DESCRIPTION
depends on #3

This is a WIP and is a follow-up to https://github.com/mswjs/interceptors/pull/283

So far it basically copies the existing `fetch.ts` tests but without a polyfill, without https support, and without any of the body/clone/request test variants.